### PR TITLE
Removed need for @export_node_path

### DIFF
--- a/examples/stat_health_example.tscn
+++ b/examples/stat_health_example.tscn
@@ -18,7 +18,6 @@ unique_name_in_owner = true
 
 [node name="StatAutoHeal" parent="StatHealth" instance=ExtResource("3_qquyk")]
 unique_name_in_owner = true
-health_stat_node = NodePath("..")
 enabled = true
 autoheal_amount = 1.0
 autoheal_rate = 0.1


### PR DESCRIPTION
Replaced with simple `@export var <var>:<Class>`.