### PR TITLE
Clamp stats

### DIFF
--- a/components/stat.gd
+++ b/components/stat.gd
@@ -49,7 +49,7 @@ signal failed(deficit: float)
 ## The current stat.
 @onready var stat := max_stat:
 	set(v):
-		stat = minf(v, max_stat)
+		stat = clamp(v, __LOWEST_LIMIT_STAT, max_stat)
 
 ## Recover an amount of the stat.
 func recover(amount: float) -> void:

--- a/components/stat_health.gd
+++ b/components/stat_health.gd
@@ -42,7 +42,7 @@ signal revived()
 ## The current health.
 @onready var health := max_health:
 	set(v):
-		health = minf(v, max_health)
+		health = clamp(v, __LOWEST_LIMIT_HEALTH, max_health)
 
 ## Apply an amount of healing.  If [i]will_revive[/i] is true, the health can be
 ## from a "dead" state.


### PR DESCRIPTION
Stats should be `clamp()`ed so that they don't go lower than the lowest allowed value (usually 0).