### PR TITLE
Fixed assert message string interpolation

### DIFF
--- a/components/movement_controls_four_way.gd
+++ b/components/movement_controls_four_way.gd
@@ -38,41 +38,41 @@ const DEFAULT_ACTION_RIGHT := "ui_right"
 func _ready() -> void:
 	if velocity_node == null:
 		velocity_node = get_parent() as MovementVelocity
-	assert(velocity_node, "No velocity_node:MovementVelocity component " + 
+	assert(velocity_node, ("No velocity_node:MovementVelocity component " + 
 		"specified in %s. Select one, or reparent this component as a child "
-		+ "of a MovementVelocity component." % [get_path()])
+		+ "of a MovementVelocity component.") % [str(get_path())])
 	
 	if input_action_up == null:
 		input_action_up = InputEventAction.new()
 		input_action_up.set_action(DEFAULT_ACTION_UP)
-	assert(input_action_up, "No input_action_up:InputEventAction resource " + 
-		"specified in %s." % [get_path()])
-	assert(input_action_up.action, "No input_action_up.action " + 
-		"specified in %s." % [get_path()])
+	assert(input_action_up, ("No input_action_up:InputEventAction resource " + 
+		"specified in %s.") % [str(get_path())])
+	assert(input_action_up.action, ("No input_action_up.action " + 
+		"specified in %s.") % [str(get_path())])
 
 	if input_action_down == null:
 		input_action_down = InputEventAction.new()
 		input_action_down.set_action(DEFAULT_ACTION_DOWN)
-	assert(input_action_down, "No input_action_down:InputEventAction " +
-		"resource specified in %s." % [get_path()])
-	assert(input_action_down.action, "No input_action_down.action " + 
-		"specified in %s." % [get_path()])
+	assert(input_action_down, ("No input_action_down:InputEventAction " +
+		"resource specified in %s.") % [str(get_path())])
+	assert(input_action_down.action, ("No input_action_down.action " + 
+		"specified in %s.") % [str(get_path())])
 	
 	if input_action_left == null:
 		input_action_left = InputEventAction.new()
 		input_action_left.set_action(DEFAULT_ACTION_LEFT)
-	assert(input_action_left, "No input_action_left:InputEventAction " +
-		"resource specified in %s." % [get_path()])
-	assert(input_action_left.action, "No input_action_left.action " + 
-		"specified in %s." % [get_path()])
+	assert(input_action_left, ("No input_action_left:InputEventAction " +
+		"resource specified in %s.") % [str(get_path())])
+	assert(input_action_left.action, ("No input_action_left.action " + 
+		"specified in %s.") % [str(get_path())])
 
 	if input_action_right == null:
 		input_action_right = InputEventAction.new()
 		input_action_right.set_action(DEFAULT_ACTION_RIGHT)
-	assert(input_action_right, "No input_action_right:InputEventAction " +
-		"resource specified in %s." % [get_path()])
-	assert(input_action_right.action, "No input_action_right.action " + 
-		"specified in %s." % [get_path()])
+	assert(input_action_right, ("No input_action_right:InputEventAction " +
+		"resource specified in %s.") % [str(get_path())])
+	assert(input_action_right.action, ("No input_action_right.action " + 
+		"specified in %s.") % [str(get_path())])
 
 func _process(_delta: float) -> void:
 	velocity_node.direction = Input.get_vector(

--- a/components/movement_controls_left_right.gd
+++ b/components/movement_controls_left_right.gd
@@ -26,25 +26,25 @@ const DEFAULT_ACTION_RIGHT := "ui_right"
 func _ready() -> void:
 	if velocity_node == null:
 		velocity_node = get_parent() as MovementVelocity
-	assert(velocity_node, "No velocity_node:MovementVelocity component " + 
+	assert(velocity_node, ("No velocity_node:MovementVelocity component " + 
 		"specified in %s. Select one, or reparent this component as a child " +
-		"of a MovementVelocity component." % [get_path()])
+		"of a MovementVelocity component.") % [str(get_path())])
 
 	if input_action_left == null:
 		input_action_left = InputEventAction.new()
 		input_action_left.set_action(DEFAULT_ACTION_LEFT)
-	assert(input_action_left, "No input_action_left:InputEventAction " +
-		"resource specified in %s." % [get_path()])
-	assert(input_action_left.action, "No input_action_left.action " + 
-		"specified in %s." % [get_path()])
+	assert(input_action_left, ("No input_action_left:InputEventAction " +
+		"resource specified in %s.") % [str(get_path())])
+	assert(input_action_left.action, ("No input_action_left.action " + 
+		"specified in %s.") % [str(get_path())])
 
 	if input_action_right == null:
 		input_action_right = InputEventAction.new()
 		input_action_right.set_action(DEFAULT_ACTION_RIGHT)
-	assert(input_action_right, "No input_action_right:InputEventAction " +
-		"resource specified in %s." % [get_path()])
-	assert(input_action_right.action, "No input_action_right.action " + 
-		"specified in %s." % [get_path()])
+	assert(input_action_right, ("No input_action_right:InputEventAction " +
+		"resource specified in %s.") % [str(get_path())])
+	assert(input_action_right.action, ("No input_action_right.action " + 
+		"specified in %s.") % [str(get_path())])
 
 
 func _process(_delta: float) -> void:

--- a/components/movement_controls_up_down.gd
+++ b/components/movement_controls_up_down.gd
@@ -26,25 +26,25 @@ const DEFAULT_ACTION_DOWN := "ui_down"
 func _ready() -> void:
 	if velocity_node == null:
 		velocity_node = get_parent() as MovementVelocity
-	assert(velocity_node, "No velocity_node:MovementVelocity component " + 
+	assert(velocity_node, ("No velocity_node:MovementVelocity component " + 
 		"specified in %s. Select one, or reparent this component as a child " +
-		"of a MovementVelocity component." % [get_path()])
+		"of a MovementVelocity component.") % [str(get_path())])
 
 	if input_action_up == null:
 		input_action_up = InputEventAction.new()
 		input_action_up.set_action(DEFAULT_ACTION_UP)
-	assert(input_action_up, "No input_action_up:InputEventAction resource " + 
-		"specified in %s." % [get_path()])
-	assert(input_action_up.action, "No input_action_up.action " + 
-		"specified in %s." % [get_path()])
+	assert(input_action_up, ("No input_action_up:InputEventAction resource " + 
+		"specified in %s.") % [str(get_path())])
+	assert(input_action_up.action, ("No input_action_up.action " + 
+		"specified in %s.") % [str(get_path())])
 
 	if input_action_down == null:
 		input_action_down = InputEventAction.new()
 		input_action_down.set_action(DEFAULT_ACTION_DOWN)
-	assert(input_action_down, "No input_action_down:InputEventAction " +
-		"resource specified in %s." % [get_path()])
-	assert(input_action_down.action, "No input_action_down.action " + 
-		"specified in %s." % [get_path()])
+	assert(input_action_down, ("No input_action_down:InputEventAction " +
+		"resource specified in %s.") % [str(get_path())])
+	assert(input_action_down.action, ("No input_action_down.action " + 
+		"specified in %s.") % [str(get_path())])
 
 func _process(_delta: float) -> void:
 	velocity_node.direction.y = Input.get_axis(

--- a/components/movement_velocity.gd
+++ b/components/movement_velocity.gd
@@ -49,9 +49,9 @@ var direction := __NO_DIRECTION
 func _ready() -> void:
 	if null == character_node:
 		character_node = get_parent() as CharacterBody2D
-	assert(character_node, "No character_node:CharacterBody2D node " + 
+	assert(character_node, ("No character_node:CharacterBody2D node " + 
 		"specified in %s. Select one, or reparent this component as a child " +
-		"of a CharacterBody2D node." % [get_path()])
+		"of a CharacterBody2D node.") % [str(get_path())])
 
 func _physics_process(_delta: float) -> void:
 	# Accelerate if we have somewhere to go.

--- a/components/stat_auto_heal.gd
+++ b/components/stat_auto_heal.gd
@@ -64,9 +64,9 @@ signal autohealing_counting_down(time_left: float)
 func _ready() -> void:
 	if health_stat_node == null:
 		health_stat_node = get_parent() as StatHealth
-	assert(health_stat_node, "No health_stat_node:StatHealth component " + 
+	assert(health_stat_node, ("No health_stat_node:StatHealth component " + 
 		"specified in %s. Select one, or reparent this component as a child " +
-		"of a StatHealth component." % [get_path()])
+		"of a StatHealth component.") % [str(get_path())])
 	
 	# Start the heal timer if the heal start timer times out.
 	__delay_timer.timeout.connect(func():

--- a/components/stat_auto_recover.gd
+++ b/components/stat_auto_recover.gd
@@ -62,9 +62,9 @@ signal autorecovery_counting_down(time_left: float)
 @onready var __recovery_timer := %RecoveryTimer
 
 func _ready() -> void:
-	assert(stat_node, "No stat_node:Stat component specified in %s. Select " +
-		"one, or reparent this component as a child of a Stat component." 
-		% [get_path()])
+	assert(stat_node, ("No stat_node:Stat component specified in %s. Select " +
+		"one, or reparent this component as a child of a Stat component.") 
+		% [str(get_path())])
 	
 	# Start the recovery timer when the delay timer times out.
 	__delay_timer.timeout.connect(func():


### PR DESCRIPTION
Concatenated strings have lower precedence than % string interpolation.  Fix that.  Also explicitly cast the results of `get_path()` to strings.